### PR TITLE
Autocomplete for Wikidata search bar

### DIFF
--- a/WDTimeline.html
+++ b/WDTimeline.html
@@ -1,5 +1,6 @@
 <html>
 	<head>
+
 		<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/d3-sparql@2.0.0/build/d3-sparql.min.js"></script>
   		<script src="https://d3js.org/d3.v5.min.js"></script>
@@ -146,10 +147,52 @@ d3.sparql(wikidataUrl, starQuery).then(function(data) {
 		</script>
 	</head>
 	<body>
-		<h3>Insert a Wikidata ID for an entity (e.g. Q937 (Albert Einstein), Q458 (European_Union), Q668 (India), Q1299 (The Beatles), etc.) to start exploring timelines:</h3>
-		<input type="text" id="text" />
-		<input type="button" id="btn" value="Submit" onClick="javascript: window.open('http://fabriziorlandi.net/sparql-epoch/WDTimeline.html?subj=http://www.wikidata.org/entity/' + document.getElementById('text').value, '_self');" />
+		<h3>Start typing something to retrieve corresponding Wikidata entities (e.g. Albert Einstein, European Union, Ireland, etc.) to start exploring timelines:</h3>
+
+		<input type="text" class="searchbox" id="text" />
+		<input type="hidden" id="textID" />
+		<input type="button" id="btn" value="Submit" onClick="javascript: window.open('http://fabriziorlandi.net/sparql-epoch/WDTimeline.html?subj=http://www.wikidata.org/entity/' + document.getElementById('textID').value, '_self');" />
+
 		<p>Or click on the items in the timeline below:</p>
 		<div id="chart_div" style="overflow-x: hidden; overflow-y: scroll; height: 800px; "></div>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.3/themes/smoothness/jquery-ui.css" />
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.3/jquery-ui.min.js"></script>
+<script type="text/javascript">
+$(".searchbox").autocomplete({
+    source: function(request, response) {
+        console.log(request.term);
+        $.ajax({
+            url: "https://www.wikidata.org/w/api.php",
+            dataType: "jsonp",
+            data: {
+                'action': "wbsearchentities",
+                'format': "json",
+		'language': "en",
+                'search': request.term
+            },
+            success: function(data) {
+                //response(data.search);
+		response( $.map(data.search, function(item) {
+			return {
+				label: item.label + " (" + item.description + ")",
+				value: item.label,
+				id: item.id,
+				description: item.description
+			}
+		}));
+            }
+        });
+    },
+    minLength: 3,
+    select: function( event, ui ) {
+	console.log( "Selected: " + ui.item.label + ", having the Wikidata entity: " + ui.item.id );
+	$("#text").val(ui.item.value);
+	$("#textID").val(ui.item.id); return false;
+    }
+});
+</script>
+
 	</body>
 </html>


### PR DESCRIPTION
Hey,

Thanks @badmotor for this great resource.

So far, the user had to give the Wikidata entity directly in the searchbar (following the form Q1234); however, it's not easy to know in advance which number corresponds to which entity…
To ease the user experience, I propose an autocompletion feature, which takes a user input string and retrieves the entity identifier on Wikidata automatically.

Hope this will help!
Cheers,